### PR TITLE
feat(rpg): Move location name to centered title

### DIFF
--- a/public/games/rpg/game.js
+++ b/public/games/rpg/game.js
@@ -490,7 +490,6 @@ function showLocationDetail(locationId) {
     const locationName = document.getElementById('location-name');
     const detailMap = document.getElementById('location-detail-map');
     const actionsContainer = document.getElementById('location-actions');
-    locationName.textContent = location.name;
     if (location.detailMap) {
         detailMap.src = location.detailMap;
     }

--- a/public/games/rpg/rpg.css
+++ b/public/games/rpg/rpg.css
@@ -211,6 +211,10 @@ body, html {
     border-radius: 10px;
 }
 
+#location-name {
+    display: none;
+}
+
 #location-title-display {
     position: absolute;
     top: 30px; /* Adjust as needed */


### PR DESCRIPTION
- Removes the location name from within the detail map card.
- Displays the location name in a new, centered title element that appears above the map when the detail view is shown.
- Hides the old H2 element for the location name to prevent layout issues.